### PR TITLE
Allow non string values for dict keys

### DIFF
--- a/examples/visitor.rs
+++ b/examples/visitor.rs
@@ -10,8 +10,8 @@ impl<'a> Visitor<'a, ()> for X<'a> {
         }
         Ok(())
     }
-    fn visit_dict_key(&mut self, key: &str, _is_first: bool) -> Result<bool, ()> {
-        Ok(key != "Fun")
+    fn visit_dict_key(&mut self, key: CborValue<'a>, _is_first: bool) -> Result<bool, ()> {
+        Ok(key.as_str() != Some("Fun"))
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -561,10 +561,16 @@ impl<'a> DictWriter<'a> {
         key: &str,
         f: impl FnOnce(SingleBuilder<'_, '_>) -> SingleResult,
     ) -> &mut Self {
-        self.0
-            .non_tracking(self.0.max_definite)
-            .write_str(key, None);
-        f(SingleBuilder(&mut self.0));
+        self.with_cbor_key(|b| b.write_str(key, None), f)
+    }
+
+    pub fn with_cbor_key(
+        &mut self,
+        k: impl FnOnce(SingleBuilder<'_, '_>) -> SingleResult,
+        v: impl FnOnce(SingleBuilder<'_, '_>) -> SingleResult,
+    ) -> &mut Self {
+        k(SingleBuilder(&mut self.0.non_tracking(self.0.max_definite)));
+        v(SingleBuilder(&mut self.0));
         self
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -605,3 +605,20 @@ fn object() {
     assert_eq!(bytes.to_string(), r#"{"Fun": true, "Amt": -2}"#);
     assert_eq!(bytes.as_slice(), str_to_bytes("0xa26346756ef563416d7421"));
 }
+
+#[test]
+fn roundtrip_non_string_map() {
+    let complex = CborBuilder::new().write_array(Some(TAG_BIGDECIMAL), |b| {
+        b.write_pos(5, None);
+        b.write_dict(None, |b| {
+            b.with_cbor_key(|b| b.write_str("1", None), |b| b.write_neg(666, None));
+            b.with_cbor_key(|b| b.write_pos(2, None), |b| b.write_bytes(b"defdef", None));
+        });
+        b.write_array(None, |b| {
+            b.write_bool(false, None);
+            b.write_str("hello", None);
+        });
+        b.write_null(Some(12345));
+    });
+    assert_eq!(complex.to_string(), "4|[5, {\"1\": -667, 2: 0x646566646566}, [false, \"hello\"], 12345|null]");
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -211,11 +211,11 @@ impl<'a> Display for CborValue<'a> {
                 }
                 Ok(true)
             }
-            fn visit_dict_key(&mut self, key: &str, is_first: bool) -> Res<bool> {
+            fn visit_dict_key(&mut self, key: CborValue<'a>, is_first: bool) -> Res<bool> {
                 if !is_first {
                     write!(*self, ", ")?;
                 }
-                write!(*self, "\"{}\": ", key.escape_debug())?;
+                write!(*self, "{}: ", key)?;
                 Ok(true)
             }
             fn visit_dict_end(&mut self) -> Res<()> {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -97,6 +97,9 @@ pub trait Visitor<'a, Err> {
     /// Visit a dict value at the given key. Return `false` to skip over the value’s
     /// contents, otherwise nested items (simple or otherwise) will be visited before visiting
     /// the next key or the dict’s end.
+    ///
+    /// In most cases the key will be a string or an integer. In the rare case where a key is a
+    /// complex struct, you can visit it manually.
     fn visit_dict_key(&mut self, key: CborValue<'a>, is_first: bool) -> Result<bool, Err> {
         Ok(true)
     }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -40,11 +40,11 @@ use crate::{
 ///             write!(self.0, "{{")?;
 ///             Ok(true)
 ///         }
-///         fn visit_dict_key(&mut self, key: &str, is_first: bool) -> Result<bool, Error> {
+///         fn visit_dict_key(&mut self, key: CborValue, is_first: bool) -> Result<bool, Error> {
 ///             if !is_first {
 ///                 write!(self.0, ", ")?;
 ///             }
-///             write!(self.0, "\"{}\": ", key.escape_debug())?;
+///             write!(self.0, "{}: ", key)?;
 ///             Ok(true)
 ///         }
 ///         fn visit_dict_end(&mut self) -> Result<(), Error> {
@@ -97,7 +97,7 @@ pub trait Visitor<'a, Err> {
     /// Visit a dict value at the given key. Return `false` to skip over the value’s
     /// contents, otherwise nested items (simple or otherwise) will be visited before visiting
     /// the next key or the dict’s end.
-    fn visit_dict_key(&mut self, key: &str, is_first: bool) -> Result<bool, Err> {
+    fn visit_dict_key(&mut self, key: CborValue<'a>, is_first: bool) -> Result<bool, Err> {
         Ok(true)
     }
     /// Visit the end of the current dict.
@@ -140,7 +140,7 @@ pub fn visit<'a, Err, V: Visitor<'a, Err>>(v: &mut V, c: CborValue<'a>) -> Resul
             let mut iter = Iter::new(bytes, length.map(|x| x * 2));
             let mut is_first = true;
             while let Some(key) = iter.next() {
-                if let Some(Str(key)) = tagged_value(key.as_slice()).map(|x| x.kind) {
+                if let Some(key) = tagged_value(key.as_slice()) {
                     if v.visit_dict_key(key, is_first)? {
                         if let Some(item) = iter
                             .next()


### PR DESCRIPTION
Without non string keys, this is not a proper CBOR library, since it wont even be able to visit anything that is produced by typical cbor libs like serde-cbor.